### PR TITLE
Change C4 to CH for PCORNet CDM 3.1

### DIFF
--- a/Oracle/pcornet_mapping.csv
+++ b/Oracle/pcornet_mapping.csv
@@ -52,7 +52,7 @@ pcori_path,local_path
 \PCORI\DEMOGRAPHIC\RACE\07\,\i2b2\Demographics\Race\Declined\
 \PCORI\DEMOGRAPHIC\RACE\05\,\i2b2\Demographics\Race\White or Caucasian\
 \PCORI\DIAGNOSIS\DX_TYPE\09\,\i2b2\Diagnoses\
-\PCORI\PROCEDURE\PX_TYPE\C4\,\i2b2\Procedures\PRC\Metathesaurus CPT Hierarchical Terms\
+\PCORI\PROCEDURE\PX_TYPE\CH\,\i2b2\Procedures\PRC\Metathesaurus CPT Hierarchical Terms\
 \PCORI\PROCEDURE\PX_TYPE\09\,\i2b2\Procedures\PRC\ICD9 (Inpatient)\
 \PCORI\VITAL\HT\,\i2b2\Visit Details\Vitals\HEIGHT\
 \PCORI\VITAL\BP\DIASTOLIC\,\i2b2\Flowsheet\KU\GEN TMP CARD ECHO VITALS T:900426\KU GEN CARD GRP CV COMMON VITALS G:910000 I#2\BLOOD PRESSURE M:5 I#2\DIASTOLIC\

--- a/Oracle/pcornet_mapping.sql
+++ b/Oracle/pcornet_mapping.sql
@@ -197,7 +197,7 @@ commit;
 create or replace view proc_local_to_pcori as
 select           '\PCORI\PROCEDURE\09\' as pcori_path, '\i2b2\Procedures\PRC\ICD9 (Inpatient)\' as local_path from dual 
 union all select '\PCORI\PROCEDURE\10\' as pcori_path, '\i2b2\Procedures\ICD10\' as local_path from dual 
-union all select '\PCORI\PROCEDURE\C4\' as pcori_path, '\i2b2\Procedures\PRC\Metathesaurus CPT Hierarchical Terms\' as local_path from dual
+union all select '\PCORI\PROCEDURE\CH\' as pcori_path, '\i2b2\Procedures\PRC\Metathesaurus CPT Hierarchical Terms\' as local_path from dual
 ;
 
 --select *


### PR DESCRIPTION
CDM 3.1 specs combine CPT (C2, C3, C4) and HCPCS (H3, HC) into a single PX_TYPE (CH). C4 is the only one of those codes that is used here.