### PR TITLE
Map relevant HERON modifiers to CDM DX_ORIGIN field

### DIFF
--- a/Oracle/pcornet_mapping.csv
+++ b/Oracle/pcornet_mapping.csv
@@ -21,6 +21,10 @@ pcori_path,local_path
 \PCORI_MOD\CONDITION_OR_DX\CONDITION_SOURCE\HC\,\Diagnosis\STATUS_C\ACTIVE\
 \PCORI_MOD\CONDITION_OR_DX\CONDITION_SOURCE\PR\,\Diagnosis\Clinical\MEDICAL_HISTORY_DX\
 \PCORI_MOD\CONDITION_OR_DX\CONDITION_SOURCE\RG\,\Diagnosis\NTDS\
+\PCORI_MOD\DX_ORIGIN\OD,\Diagnosis\Clinical\PRIMARY_DX_YN\
+\PCORI_MOD\DX_ORIGIN\BI,\Diagnosis\Billing\UKP\
+\PCORI_MOD\DX_ORIGIN\BI,\Diagnosis\Billing\UHC_DIAGNOSIS\
+\PCORI_MOD\DX_ORIGIN\BI,\Diagnosis\Billing\Primary\
 \PCORI\DEMOGRAPHIC\BIOBANK_FLAG\Y\,\i2b2\Specimens\
 \PCORI\DEMOGRAPHIC\HISPANIC\N\,"\i2b2\Demographics\Ethnicity\Non Hispanic, Latino or Spanish Origin\"
 \PCORI\DEMOGRAPHIC\HISPANIC\NI\,\i2b2\Demographics\Ethnicity\Not Recorded\

--- a/Oracle/pcornet_mapping.csv
+++ b/Oracle/pcornet_mapping.csv
@@ -7,12 +7,8 @@ pcori_path,local_path
 \PCORI_MOD\RX_BASIS\PR\01\,\Medication\Outpatient\
 \PCORI_MOD\RX_BASIS\PR\02\,\Medication\PRN Inpatient Order\
 \PCORI_MOD\PDX\P\,\Diagnosis\\modifier_dx\billing_diagnosis\discharge\discharge_primary\
-\PCORI_MOD\PDX\P\,\Diagnosis\Billing\Primary\
 \PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\DI\,\Diagnosis\\modifier_dx\billing_diagnosis\discharge\
 \PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\AD\,\Diagnosis\\modifier_dx\billing_diagnosis\admit\
-"\PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\UN\","\Diagnosis\Billing\UHC_DIAGNOSIS\"
-"\PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\FI\","\Diagnosis\Billing\UKP\"
-"\PCORI_MOD\PDX\X\","\Diagnosis\Billing\Primary\"
 "\PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\FI\","\Diagnosis\\modifier_dx\billing_diagnosis\professional\"
 "\PCORI_MOD\PDX\X\","\Diagnosis\\modifier_dx\billing_diagnosis\professional\professional_primary\"
 \PCORI_MOD\CONDITION_OR_DX\CONDITION_SOURCE\HC\,\Diagnosis\Clinical\HOSPITAL_PL_YN\

--- a/Oracle/pcornet_mapping.csv
+++ b/Oracle/pcornet_mapping.csv
@@ -7,8 +7,12 @@ pcori_path,local_path
 \PCORI_MOD\RX_BASIS\PR\01\,\Medication\Outpatient\
 \PCORI_MOD\RX_BASIS\PR\02\,\Medication\PRN Inpatient Order\
 \PCORI_MOD\PDX\P\,\Diagnosis\\modifier_dx\billing_diagnosis\discharge\discharge_primary\
+\PCORI_MOD\PDX\P\,\Diagnosis\Billing\Primary\
 \PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\DI\,\Diagnosis\\modifier_dx\billing_diagnosis\discharge\
 \PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\AD\,\Diagnosis\\modifier_dx\billing_diagnosis\admit\
+"\PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\UN\","\Diagnosis\Billing\UHC_DIAGNOSIS\"
+"\PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\FI\","\Diagnosis\Billing\UKP\"
+"\PCORI_MOD\PDX\X\","\Diagnosis\Billing\Primary\"
 "\PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\FI\","\Diagnosis\\modifier_dx\billing_diagnosis\professional\"
 "\PCORI_MOD\PDX\X\","\Diagnosis\\modifier_dx\billing_diagnosis\professional\professional_primary\"
 \PCORI_MOD\CONDITION_OR_DX\CONDITION_SOURCE\HC\,\Diagnosis\Clinical\HOSPITAL_PL_YN\


### PR DESCRIPTION
There was some discussion with Mike and Tamara about which modifiers belonged in the Diagnosis table and which ones belonged in the Condition table; this mapping is the result, but it's not final yet.