### PR TITLE
act_test_queries: apply ocap discipline, python style

### DIFF
--- a/Oracle/act_test_queries.py
+++ b/Oracle/act_test_queries.py
@@ -13,11 +13,14 @@ def main(environ, sleep, Chrome,
          base="http://herondev:8080/shrine-api/shrine-webclient/"):
     driver = Chrome(executable_path=executable_path, options=big_headless())
 
-    login(driver, sleep, base, environ['ACT_USER'], environ['ACT_PASS'])
-    query_list_by_name = find_flagged_queries(driver, sleep)
-    for i in query_list_by_name:
-        run_query(driver, sleep, i)
-    driver.close()
+    try:
+        login(driver, sleep, base, environ['ACT_USER'], environ['ACT_PASS'])
+        query_list_by_name = find_flagged_queries(driver, sleep)
+        for i in query_list_by_name:
+            run_query(driver, sleep, i)
+    finally:
+        driver.close()
+        driver.quit()
 
 
 def big_headless():

--- a/Oracle/act_test_queries.py
+++ b/Oracle/act_test_queries.py
@@ -9,10 +9,11 @@ log = logging.getLogger(__name__)
 
 
 def main(environ, sleep, Chrome,
-         executable_path="./chromedriver",
-         base="http://herondev:8080/shrine-api/shrine-webclient/"):
-    driver = Chrome(executable_path=executable_path, options=big_headless())
+         executable_path="./chromedriver"):
+    origin = environ['ACT_ORIGIN'] or 'http://herondev:8080'
+    base = f"{origin}/shrine-api/shrine-webclient/"
 
+    driver = Chrome(executable_path=executable_path, options=big_headless())
     try:
         login(driver, sleep, base, environ['ACT_USER'], environ['ACT_PASS'])
         query_list_by_name = find_flagged_queries(driver, sleep)

--- a/Oracle/act_test_queries.py
+++ b/Oracle/act_test_queries.py
@@ -1,83 +1,139 @@
 #!/usr/bin/python3
 
-import os
-import time
+import logging
 
-from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver import ChromeOptions
 
-chrome_options = webdriver.ChromeOptions()
-chrome_options.add_argument('--headless')
-# window size matters:
-# `Other element would receive the click: <div class="py-3 Footer"></div>`
-chrome_options.add_argument('--window-size=1920,1080')
-driver = webdriver.Chrome(executable_path="./chromedriver", options=chrome_options)
+log = logging.getLogger(__name__)
 
-#login
-print("Logging in...")
-driver.get("http://herondev:8080/shrine-api/shrine-webclient/#/login")
-user_box = driver.find_element_by_name('username')
-user_box.send_keys(os.environ['ACT_USER'])
-pass_box = driver.find_element_by_name('password')
-pass_box.send_keys(os.environ['ACT_PASS'])
-pass_box.send_keys(Keys.RETURN)
 
-# race after login
-time.sleep(1)
+def main(environ, sleep, Chrome,
+         executable_path="./chromedriver",
+         base="http://herondev:8080/shrine-api/shrine-webclient/"):
+    driver = Chrome(executable_path=executable_path, options=big_headless())
 
-# on first login, we get some help boxes
-driver.find_element_by_xpath('//*[@id="tippy-1"]/div/div/div/header/button').click()
+    login(driver, sleep, base, environ['ACT_USER'], environ['ACT_PASS'])
+    query_list_by_name = find_flagged_queries(driver, sleep)
+    for i in query_list_by_name:
+        run_query(driver, sleep, i)
+    driver.close()
 
-print("Searching for flagged queries...")
-# ensure we're on the find patients page
-driver.find_element_by_xpath('//*[@id="app"]/header/div/div[3]/div[1]/div/div/button[2]/span[1]').click()
-# wait for list to load
-time.sleep(3)
-# sort by flags
-driver.find_element_by_xpath('//*[@id="app"]/div[1]/div[1]/div/div[1]/div/div[2]/table/thead/tr/th[4]/span/i').click()
-time.sleep(2)
-flagged_query_list = driver.find_elements_by_xpath("//i[@class='fa fa-flag hover-controls flagged']")
 
-query_list_by_name = []
+def big_headless():
+    chrome_options = ChromeOptions()
+    chrome_options.add_argument('--headless')
+    # window size matters:
+    # `Other element would receive the click: <div class="py-3 Footer"></div>`
+    chrome_options.add_argument('--window-size=1920,1080')
+    return chrome_options
 
-for i in flagged_query_list:
-    query_name = i.find_element_by_xpath('..').find_element_by_xpath("../td[@class='MuiTableCell-root MuiTableCell-body queryHistoryName']").text
-    print("Found query: " + query_name)
-    query_list_by_name.append(query_name)
 
-for i in query_list_by_name:
-    time.sleep(1)
-    print("Selecting " + i)
+def login(driver, sleep, base, username, password):
+    log.info("Logging in...")
+    driver.get(f"{base}#/login")
+    user_box = driver.find_element_by_name('username')
+    user_box.send_keys(username)
+    pass_box = driver.find_element_by_name('password')
+    pass_box.send_keys(password)
+    pass_box.send_keys(Keys.RETURN)
+
+    # race after login
+    sleep(1)
+
+    # on first login, we get some help boxes
+    driver.find_element_by_xpath(
+        '//*[@id="tippy-1"]/div/div/div/header/button').click()
+
+
+def find_flagged_queries(driver, sleep):
+    log.info("Searching for flagged queries...")
+    # ensure we're on the find patients page
+    driver.find_element_by_xpath(
+        '//*[@id="app"]/header/'
+        'div/div[3]/div[1]/div/div/button[2]/span[1]').click()
+    # wait for list to load
+    sleep(3)
+    # sort by flags
+    driver.find_element_by_xpath(
+        '//*[@id="app"]/div[1]/div[1]/div/div[1]/div/div[2]/'
+        'table/thead/tr/th[4]/span/i').click()
+    sleep(2)
+    flagged_query_list = driver.find_elements_by_xpath(
+        "//i[@class='fa fa-flag hover-controls flagged']")
+
+    query_list_by_name = []
+
+    for i in flagged_query_list:
+        query_name = i.find_element_by_xpath('..').find_element_by_xpath(
+            "../td[@class="
+            "'MuiTableCell-root MuiTableCell-body queryHistoryName']").text
+        log.info("Found query: " + query_name)
+        query_list_by_name.append(query_name)
+    return query_list_by_name
+
+
+def run_query(driver, sleep, i):
+    sleep(1)
+    log.info("Selecting " + i)
     driver.find_element_by_xpath("//td[contains(text(),'" + i + "')]").click()
-    time.sleep(1)
-    ## run query
+    sleep(1)
+    # - run query
     # edit button
-    print("Running " + i)
-    driver.find_element_by_xpath('//*[@id="app"]/div[1]/div[1]/div/div[2]/div[2]/div[1]/div/button').click()
-    time.sleep(2)
+    log.info("Running " + i)
+    driver.find_element_by_xpath(
+        '//*[@id="app"]/div[1]/div[1]/div/'
+        'div[2]/div[2]/div[1]/div/button').click()
+    sleep(2)
     # topic dropdown
-    driver.find_element_by_xpath("//div[@class='MuiInputBase-root MuiInput-root MuiInput-underline topic-select  MuiInputBase-formControl MuiInput-formControl']").click()
-    time.sleep(1)
+    driver.find_element_by_xpath(
+        "//div[@class="
+        "'MuiInputBase-root MuiInput-root MuiInput-underline topic-select "
+        " MuiInputBase-formControl MuiInput-formControl']").click()
+    sleep(1)
     # test topic
     driver.find_element_by_xpath("//li[contains(text(),'test')]").click()
     # run query
-    driver.find_element_by_xpath('//*[@id="app"]/div[1]/div[1]/div/div[2]/div[2]/div[3]/div/div[1]/div/div[3]/button').click()
+    driver.find_element_by_xpath(
+        '//*[@id="app"]/div[1]/div[1]/div/div[2]/div[2]/div[3]/'
+        'div/div[1]/div/div[3]/button').click()
     # get results
     for attempt in range(60):
         try:
             try:
-                result=driver.find_element_by_xpath("//div[@class='PatientCount']").text
-            except:
-                result=driver.find_element_by_xpath("//div[@class='SiteError']").text
-            if result in ('10 patients or fewer', 'Site Error click for details'):
-                print(i + " result: \033[93m" + result + "\033[0m")
+                result = driver.find_element_by_xpath(
+                    "//div[@class='PatientCount']").text
+            except Exception:
+                result = driver.find_element_by_xpath(
+                    "//div[@class='SiteError']").text
+            if result in ('10 patients or fewer',
+                          'Site Error click for details'):
+                log.info(i + " result: " + highlight(result))
             else:
-                print(i + " result: " + result)
-        except:
-            time.sleep(1)
+                log.info(i + " result: " + result)
+        except Exception:
+            sleep(1)
             continue
         break
     else:
-        print("Query " + i + " \033[93mfailed to execute\033[0m")
+        log.info("Query " + i + " " + highlight("failed to execute"))
 
-driver.close()
+
+def highlight(txt):
+    return f"\033[93m{txt}\033[0m"
+
+
+if __name__ == '__main__':
+    def _script_io():
+        from os import environ
+        from time import sleep
+        from sys import stderr
+
+        from selenium.webdriver import Chrome
+
+        logging.basicConfig(level=logging.INFO,
+                            stream=stderr)
+
+        main(environ, sleep, Chrome)
+
+    _script_io()

--- a/Oracle/act_test_queries.py
+++ b/Oracle/act_test_queries.py
@@ -135,8 +135,11 @@ if __name__ == '__main__':
 
         from selenium.webdriver import Chrome
 
-        logging.basicConfig(level=logging.INFO,
-                            stream=stderr)
+        logging.basicConfig(
+            level=logging.INFO,
+            format='%(asctime)s %(levelname)s %(funcName)s: %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S',
+            stream=stderr)
 
         main(environ, sleep, Chrome)
 


### PR DESCRIPTION
 - clarify structure using ~10 line main()
   plus functions for big_headless() ChromeOptions,
   login(), find_flagged_queries(), run_query()
   - hoist base URL to default arg to expose it as part of the API
 - put all effects in functions to allow module to be imported without
   effects
 - pass access to sleep, environ, Chrome explicitly;
   don't import powerful references at module scope
 - use logging rather than print()
 - factor out hightlight() escape code magic
 - python community style (pep8)
   - limit line length to 80
     - somewhat awkward with long xpaths. hm.
   - no bare `except:`
   - whitespace after # comment delimiter